### PR TITLE
Issue #19

### DIFF
--- a/test/test_feels.py
+++ b/test/test_feels.py
@@ -122,8 +122,11 @@ class Test_Feels(unittest.TestCase):
         #      = -0.01299649
         self.mock_feels._latest_calc = self.mock_feels._feels.start
         self.assertTrue(np.isclose(self.mock_feels.sentiment, sentiment))
+        # first observation is at 2017-2-19 19:14:18 and we are using default
+        # 60 second bins, therefore the observation at 2017-2-21 19:14:20 will
+        # never get saved but will always be recalculated.
         self.assertEqual(self.mock_feels._latest_calc,
-                         self.mock_feels._feels.end)
+                         datetime(2017, 2, 21, 19, 14, 18))
 
     def test_sentiments(self):
         for t in self.mock_tweets:
@@ -138,5 +141,7 @@ class Test_Feels(unittest.TestCase):
         self.assertTrue(np.isclose(next(sentiment), -0.01299649))
         for s in sentiment:
             print(s)
+        # we are starting at 2017-2-19 19:00:00 and using bins with lenght 1 day
+        # therefore our latest calc will be just prior to the last observation.
         self.assertEqual(self.mock_feels._latest_calc,
-                         self.mock_feels._feels.end)
+                         datetime(2017, 2, 21, 0, 0, 0))

--- a/test/test_feels.py
+++ b/test/test_feels.py
@@ -47,10 +47,10 @@ class Test_Feels(unittest.TestCase):
     def test_start(self):
         mock_feels = TweetFeels("abcd")
         mock_feels.tracking = []
-        mock_feels.start()
+        mock_feels.start(selfupdate=0)
         mock_feels._stream.filter.assert_not_called()
         mock_feels.tracking = ['tsla']
-        mock_feels.start()
+        mock_feels.start(selfupdate=0)
         mock_feels._stream.filter.assert_called_once()
 
     def test_stop(self):
@@ -141,7 +141,7 @@ class Test_Feels(unittest.TestCase):
         self.assertTrue(np.isclose(next(sentiment), -0.01299649))
         for s in sentiment:
             print(s)
-        # we are starting at 2017-2-19 19:00:00 and using bins with lenght 1 day
-        # therefore our latest calc will be just prior to the last observation.
+        # we are starting at 2017-2-19 19:00:00 and using bins with length 1 day
+        # therefore our latest calc will be just prior to the final observation.
         self.assertEqual(self.mock_feels._latest_calc,
                          datetime(2017, 2, 21, 0, 0, 0))

--- a/test/test_feels.py
+++ b/test/test_feels.py
@@ -128,6 +128,11 @@ class Test_Feels(unittest.TestCase):
         self.assertEqual(self.mock_feels._latest_calc,
                          datetime(2017, 2, 21, 19, 14, 18))
 
+        # repeat the calculation, nothing changes
+        self.assertTrue(np.isclose(self.mock_feels.sentiment, sentiment))
+        self.assertEqual(self.mock_feels._latest_calc,
+                         datetime(2017, 2, 21, 19, 14, 18))
+
     def test_sentiments(self):
         for t in self.mock_tweets:
             self.feels_db.insert_tweet(t)

--- a/tweetfeels/tweetdata.py
+++ b/tweetfeels/tweetdata.py
@@ -90,6 +90,7 @@ class TweetData(object):
         if end is None: end=self.end
         second = timedelta(seconds=1)
         df = self.tweet_dates
+        df = df[df.index >= start]
         df = df.groupby(pd.TimeGrouper(freq=f'{int(binsize/second)}S')).size()
         df = df[df != 0]
         conn = sqlite3.connect(self._db, detect_types=sqlite3.PARSE_DECLTYPES)

--- a/tweetfeels/tweetdata.py
+++ b/tweetfeels/tweetdata.py
@@ -86,24 +86,26 @@ class TweetData(object):
         :param binsize: Time duration for each bin for tweet grouping.
         :type binsize: timedelta
         """
-        if start is None: start=self.start
-        if end is None: end=self.end
         second = timedelta(seconds=1)
+        if start is None: start=self.start-second
+        if end is None: end=self.end
+        if start == self.start: start = start-second
         df = self.tweet_dates
-        df = df[df.index >= start]
         df = df.groupby(pd.TimeGrouper(freq=f'{int(binsize/second)}S')).size()
+        df = df[df.index > start - binsize]
         df = df[df != 0]
         conn = sqlite3.connect(self._db, detect_types=sqlite3.PARSE_DECLTYPES)
         c = conn.cursor()
         c.execute(
-            "SELECT * FROM tweets WHERE created_at >= ? AND created_at <= ?",
+            "SELECT * FROM tweets WHERE created_at > ? AND created_at <= ?",
             (start, end)
             )
-        for i in range(len(df)):
-            yield pd.DataFrame.from_records(
+        for i in range(0,len(df)):
+            frame = pd.DataFrame.from_records(
                 data=c.fetchmany(df.iloc[i]), columns=self.fields,
                 index='created_at'
                 )
+            if len(frame)>0: yield frame
         c.close()
 
     def tweets_since(self, dt):

--- a/tweetfeels/tweetdata.py
+++ b/tweetfeels/tweetdata.py
@@ -100,7 +100,8 @@ class TweetData(object):
             )
         for i in range(len(df)):
             yield pd.DataFrame.from_records(
-                data=c.fetchmany(df.iloc[i]), columns=self.fields
+                data=c.fetchmany(df.iloc[i]), columns=self.fields,
+                index='created_at'
                 )
         c.close()
 

--- a/tweetfeels/tweetfeels.py
+++ b/tweetfeels/tweetfeels.py
@@ -172,13 +172,14 @@ class TweetFeels(object):
             dfs = self._feels.fetchbin(
                 start=self._latest_calc, end=end, binsize=delta_time
                 )
-            sentiment = deque([self._sentiment])
+            sentiment = deque()
             for df in dfs:
                 try:
                     # only save sentiment value if not the last element
                     self._sentiment = sentiment.popleft()
                 except IndexError:
                     pass
+
                 sentiment.append(self.model_sentiment(df, self._sentiment))
                 bins = int((df.index.max().to_pydatetime() -
                             self._latest_calc)/delta_time)

--- a/tweetfeels/tweetfeels.py
+++ b/tweetfeels/tweetfeels.py
@@ -180,7 +180,8 @@ class TweetFeels(object):
                 except IndexError:
                     pass
                 sentiment.append(self.model_sentiment(df, self._sentiment))
-                bins = int((df.index.max() - self._latest_calc)/delta_time)
+                bins = int((df.index.max().to_pydatetime() -
+                            self._latest_calc)/delta_time)
                 self._latest_calc =  self._latest_calc + bins*delta_time
                 # Yield the latest element
                 yield sentiment[-1]

--- a/tweetfeels/tweetfeels.py
+++ b/tweetfeels/tweetfeels.py
@@ -180,7 +180,7 @@ class TweetFeels(object):
                 except IndexError:
                     pass
                 sentiment.append(self.model_sentiment(df, self._sentiment))
-                bins = int((df.created_at - self._latest_calc)/delta_time)
+                bins = int((df.index.max() - self._latest_calc)/delta_time)
                 self._latest_calc =  self._latest_calc + bins*delta_time
                 # Yield the latest element
                 yield sentiment[-1]

--- a/tweetfeels/tweetfeels.py
+++ b/tweetfeels/tweetfeels.py
@@ -46,18 +46,24 @@ class TweetFeels(object):
         self._tweet_buffer = deque()
         self.buffer_limit = 50
 
-    def start(self, seconds=None):
+    def start(self, seconds=None, selfupdate=60):
         """
         Start listening to the stream.
 
         :param seconds: If you want to automatically disconnect after a certain
                         amount of time, pass the number of seconds into this
                         parameter.
+        :param selfupdate: Number of seconds between auto-calculate.
         """
         def delayed_stop():
             time.sleep(seconds)
             print('Timer completed. Disconnecting now...')
             self.stop()
+
+        def self_update():
+            while self.connected:
+                time.sleep(selfupdate)
+                self.sentiment
 
         if len(self.tracking) == 0:
             print('Nothing to track!')
@@ -74,6 +80,10 @@ class TweetFeels(object):
         if seconds is not None:
             t = Thread(target=delayed_stop)
             t.start()
+
+        if selfupdate is not None and selfupdate > 0:
+            t2 = Thread(target=self_update)
+            t2.start()
 
     def stop(self):
         """

--- a/tweetfeels/tweetfeels.py
+++ b/tweetfeels/tweetfeels.py
@@ -172,7 +172,7 @@ class TweetFeels(object):
             dfs = self._feels.fetchbin(
                 start=self._latest_calc, end=end, binsize=delta_time
                 )
-            sentiment = deque()
+            sentiment = deque([self._sentiment])
             for df in dfs:
                 try:
                     # only save sentiment value if not the last element
@@ -185,6 +185,9 @@ class TweetFeels(object):
                 self._latest_calc =  self._latest_calc + bins*delta_time
                 # Yield the latest element
                 yield sentiment[-1]
+        else:
+            # this only happens when strt >= end
+            yield self._sentiment
 
     def model_sentiment(self, df, s, fo=0.99):
         """

--- a/tweetfeels/tweetfeels.py
+++ b/tweetfeels/tweetfeels.py
@@ -215,6 +215,7 @@ class TweetFeels(object):
         sentiments = self.sentiments(
             strt=self._latest_calc, end=end, delta_time=self._bin_size
             )
+        ret = None
         for s in sentiments:
-            self._sentiment = s
-        return self._sentiment
+            ret = s
+        return ret


### PR DESCRIPTION
Addresses the following:
* tweetfeels will keep sentiment up to date for #19 
 * default is to refresh every minute, you can turn it off (set to 0) or increase it.
* When auto-update is running, a large backlog of unprocessed tweets will not build-up, which alleviates #18