### PR TITLE
Add default sentiment (None) to fix #35

### DIFF
--- a/tweetfeels/tweetfeels.py
+++ b/tweetfeels/tweetfeels.py
@@ -128,6 +128,7 @@ class TweetFeels(object):
         sentiments = self.sentiments(
             strt=self._latest_calc, end=end, delta_time=self._bin_size
             )
+        s = None
         for s in sentiments:
             pass
         return s


### PR DESCRIPTION
Looks like a bug was introduced in 45f610398f2e422653178459e4610d1900378d0c. The value of `s` is defined in the for loop, so if the generator is empty, s never gets that definition and results in the UnboundLocalError.

```
@property
def sentiment(self):
    end = self._feels.end
    sentiments = self.sentiments(
        strt=self._latest_calc, end=end, delta_time=self._bin_size
        )
    for s in sentiments:
        pass
    return s
```
I initialized `s` as None (which seems reasonable to me).